### PR TITLE
Increase LoRA multiplier slider max to 5.0

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -146,13 +146,18 @@ class LoraMultipliersUIPlugin(WAN2GPPlugin):
                         container.className = 'lora-slider-group';
                         if (!isVisible) container.classList.add('hidden');
 
+                        const maxMultiplier = 5;
                         const initialValue = parseFloat(value);
+                        const safeInitialValue = Math.max(
+                            0,
+                            Math.min(maxMultiplier, isNaN(initialValue) ? 1.0 : initialValue)
+                        );
 
                         container.innerHTML = `
                             <label>Phase ${{phase}}</label>
                             <div class="lora-slider-input-wrapper">
-                                <input type="range" min="0" max="1" step="0.05" value="${{initialValue}}">
-                                <input type="number" min="0" max="1" step="0.05" value="${{initialValue.toFixed(2)}}">
+                                <input type="range" min="0" max="${{maxMultiplier}}" step="0.05" value="${{safeInitialValue}}">
+                                <input type="number" min="0" max="${{maxMultiplier}}" step="0.05" value="${{safeInitialValue.toFixed(2)}}">
                             </div>
                         `;
 
@@ -162,7 +167,7 @@ class LoraMultipliersUIPlugin(WAN2GPPlugin):
                         const syncAndUpdate = (source) => {{
                             let val = parseFloat(source.value);
                             if (isNaN(val)) val = 0;
-                            val = Math.max(0, Math.min(1, val));
+                            val = Math.max(0, Math.min(maxMultiplier, val));
 
                             if (source === rangeInput) {{
                                 numberInput.value = val.toFixed(2);
@@ -428,3 +433,4 @@ class LoraMultipliersUIPlugin(WAN2GPPlugin):
         
 
         return {}
+        


### PR DESCRIPTION
Updates the Dynamic LoRA Multipliers UI to support values from 0 to 5 in 0.05 increments.

Wan2GP supports LoRA multiplier values above 1.0, but this plugin's slider, number input, and JavaScript clamp were capped at 1.0. Some newer LoRAs like a little more oomph. Yes you can input the numbers manually but everybody loves a slider.

Tested locally in Wan2GP: the slider and number input correctly and populate the LoRA Multipliers field with values up to 5.0.